### PR TITLE
Polish usage information on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@
 
 It gets difficult to keep your repositories clean as your project scales with more and more developers.
 It would be ideal if developers could always clean up the branches that they created when the branches are no longer used.
-However, in reality, it takes some time and energy to make sure stale branches are deleted in a timely manner.
+However, in reality, it takes some time and energy to make sure unused branches are deleted in a timely manner.
 
-### What are stale branches?
+### What are unused branches?
 
 [According to Github](https://help.github.com/en/articles/viewing-branches-in-your-repository), stale branches are all branches that no one has committed to in the last three months. They are considered to be branches to delete.
 
-### Why you forget to delete them?
+### Why we easily forget to delete them?
 
 -   Developers just forget to delete it once the branch is merged or forget about temporary branches that they created for experiment or research.
--   Branches are not always merged not by the developer. It can be merged by a QA or another developer.
+-   Branches are not always merged not by the developer. It can be merged by a QA or another developer and they hesitate to delete others' branches.
 -   When someone leaves your team/organization, he or she often leaves all of his branches uncleaned.
 
 ## Solution
 
-Branch Cleaner is a very simple solution for preventing your repositories from being polluted with stale branches.
-This Slack bot reminds you of stale branches and enable you to delete them right away on Slack.
+Branch Cleaner is a very simple solution for preventing your repositories from being polluted with unused branches.
+This Slack bot reminds you of unused branches and enable you to delete them right away on Slack.
 It encourages developers to be aware of branches that they forgot to delete and get into the habit of cleaning up repositories themselves.
 
 ![ScreenShot](./ScreenShot.png)
@@ -31,13 +31,13 @@ It encourages developers to be aware of branches that they forgot to delete and 
 This Slack bot does the following tasks travelling back and forth between [Github API](https://api.github.com) and [Slack API](https://api.slack.com/).
 
 -   Fetch all branches of a repository from Github.
--   Search for stale branches and order them with the oldest ones first.
--   Post messages containing the detail on stale branches and a delete button to a channel on Slack.
--   When the delete button on a message is clicked, delete the branch from Github repository and then update the Slack message.
+-   Search for unused branches and order them with the oldest ones first.
+-   Post messages containing the detail on unused branches and a delete button to the channel of your choice on Slack.
+-   When the delete button on a message is clicked, delete the branch from the Github repository and then update the Slack message.
 
 ## API (Serverless functions)
 
--   Remind of stale branches on slack. (Schedule it to be triggered regularly and also can call it manually.)
+-   Remind of unused branches on slack. (Schedule it to be triggered regularly and also can call it manually.)
 
 ```sh
 curl "http://localhost:9000/remind?owner=<owner>&repository=<repository>&channel=<channel>"
@@ -64,18 +64,14 @@ Use environment variables or create `.env` file to define the following config i
 $ npm test
 ```
 
-## Run serverless functions locally
-
-```
-$ npm run serve
-```
-
-## Build serverless functions
+## Build app
 
 ```
 $ npm run build
 ```
 
-## Deploy serverless functions
+## Run app
 
-Once new changes are built and a commit is pushed to master, it gets deployed immediately to Netlify.
+```
+$ npm run serve
+```


### PR DESCRIPTION
This PR polishes the usage information in `REAME.md` as follows.

- Use the word `unuse` instead of `stale` considering that there is a feature request that Branch Cleaner take care of merged branches as well as stale branches.
- Reorder steps to use the app. (Should build it earlier than running it.)
- Remove the extra step to host the app on Netlify because this app doesn't need to be hosted on Netlify though it would be the easiest way.