### PR TITLE
Option to exempt branches

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const {
     GITHUB_ENDPOINT = 'https://api.github.com',
     GITHUB_TOKEN,
     GITHUB_OWNER,
+    GITHUB_EXCLUDE,
     SLACK_ENDPOINT = 'https://slack.com/api',
     SLACK_TOKEN
 } = process.env;
@@ -15,7 +16,8 @@ module.exports = {
     github: {
         endpoint: GITHUB_ENDPOINT,
         token: GITHUB_TOKEN,
-        owner: GITHUB_OWNER
+        owner: GITHUB_OWNER,
+        exclude: GITHUB_EXCLUDE ? GITHUB_EXCLUDE.trim().split(',') : []
     },
     slack: {
         endpoint: SLACK_ENDPOINT,

--- a/src/github/filterStaleBranches.js
+++ b/src/github/filterStaleBranches.js
@@ -1,9 +1,13 @@
-module.exports = nodes => {
+const { github } = require('../config');
+
+module.exports = ({ nodes, excludedBranches = github.exclude }) => {
     const past = new Date();
     past.setMonth(past.getMonth() - 3);
 
     const staleBranches = nodes.filter(
         ({ target: { committedDate } }) => Date.parse(committedDate) < past
+    ).filter(
+        ({ name }) => !excludedBranches.includes(name)
     );
 
     staleBranches.sort((a, b) => a.target.committedDate.localeCompare(b.target.committedDate));

--- a/src/github/filterStaleBranches.test.js
+++ b/src/github/filterStaleBranches.test.js
@@ -1,0 +1,66 @@
+const filterStaleBranches = require('./filterStaleBranches');
+const axios = require('axios');
+
+jest.mock('axios');
+
+test('filterStaleBranches() excludes specifed branches', async () => {
+    // given
+    const past = new Date();
+    past.setMonth(past.getMonth() - 4);
+
+    const nodes = ['bugfix/foo', 'bugfix/bar', 'develop', 'feature/foo', 'feature/bar', 'master']
+        .map(name => ({
+            name: name,
+            target: {
+              committedDate: past.toISOString(),
+              author: { user: {} }
+            }
+        }));
+    const excludedBranches = ['master', 'develop'];
+
+    // when
+    const branches = filterStaleBranches({ nodes, excludedBranches });
+
+    // then
+    expect(branches.map(({ name }) => name)).toEqual(
+        expect.not.arrayContaining(excludedBranches)
+    );
+});
+
+test('filterStaleBranches() filter by committed date', async () => {
+    // given
+    const past = new Date();
+    past.setMonth(past.getMonth() - 4);
+
+    const staleBranches = ['stale-1', 'stale-2'];
+    const freshBranches = ['fresh-1', 'fresh-2', 'fresh-3']
+
+    const nodes = [
+        ...staleBranches.map(name => ({
+            name: name,
+            target: {
+              committedDate: past.toISOString(),
+              author: { user: {} }
+            }
+        })),
+        ...freshBranches.map(name => ({
+            name: name,
+            target: {
+              committedDate: new Date().toISOString(),
+              author: { user: {} }
+            }
+        }))
+    ]
+
+    // when
+    const branches = filterStaleBranches({ nodes });
+
+    // then
+    expect(branches.map(({ name }) => name)).toEqual(
+        expect.arrayContaining(staleBranches)
+    );
+
+    expect(branches.map(({ name }) => name)).toEqual(
+        expect.not.arrayContaining(freshBranches)
+    );
+});

--- a/src/github/findStaleBranches.js
+++ b/src/github/findStaleBranches.js
@@ -4,5 +4,5 @@ const filterStaleBranches = require('./filterStaleBranches');
 module.exports = async ({ owner, repository }) => {
     const nodes = await fetchBranches({ owner, repository });
     console.log('nodes:', nodes);
-    return filterStaleBranches(nodes);
+    return filterStaleBranches({ nodes });
 };

--- a/src/github/findStaleBranches.test.js
+++ b/src/github/findStaleBranches.test.js
@@ -28,6 +28,6 @@ describe('findStaleBranches()', () => {
         await findStaleBranches({ owner, repository });
 
         expect(filterStaleBranches).toBeCalledTimes(1);
-        expect(filterStaleBranches).toBeCalledWith(nodes);
+        expect(filterStaleBranches).toBeCalledWith({ nodes });
     });
 });


### PR DESCRIPTION
This PR enables the app to exempt some branches through simple settings.

Some devs have been asking they want to exclude their branches for different reasons.
Considering the purpose of the app is to keep Git repositories clean, I personally think even if we have this feature added, it should be used sparingly and these branches should be moved to a forked repository.
Nevertheless, I decided to work on this feature because it can also be used to exclude default or protected branches such as `master`, `develop`, which can have unexpected implications.
