### PR TITLE
Put a missing return back

### DIFF
--- a/src/slack/composeBlocks.js
+++ b/src/slack/composeBlocks.js
@@ -1,5 +1,5 @@
 module.exports = ({ repository, branches }) => {
-  branches.map(({ name, date, user }) => {
+  return branches.map(({ name, date, user }) => {
     const link = `>*<https://github.com/SMARTeacher/${repository}/tree/${name}|${name}>*`;
     const meta = `>:alarm_clock: _${date}_ :ed: _${user.name || user.login || user.email}_`;
     return {


### PR DESCRIPTION
A critical bug was introduced because a return statement was accidentally disappeared while fixing linting issues in the previous PR #16.
To prevent this kind of mistake in the future, we should make sure linting and testing automatically happen and should be followed up on issue #18.