### PR TITLE
Don't lint or format the lambda directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
-node_modules
+node_modules/
+lambda/
 package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules/
+lambda/
 package-lock.json


### PR DESCRIPTION
Once you `npm run build` or `nm run serve`, you will get the lambda directory created locally where Netlify Lambda puts bundles. We don't want to deal with linting issues caused by those minified pieces of code.