### PR TITLE
exclude default branch 

### DIFF
--- a/src/github/fetchBranches.js
+++ b/src/github/fetchBranches.js
@@ -45,5 +45,5 @@ module.exports = async ({ owner = github.owner, repository }) => {
     },
   } = response.data.data;
 
-  return { nodes, defaultBranchName: name };
+  return { nodes, defaultBranch: name };
 };

--- a/src/github/fetchBranches.js
+++ b/src/github/fetchBranches.js
@@ -6,7 +6,7 @@ module.exports = async ({ owner = github.owner, repository }) => {
   const query = `{
         repository(name: "${repository}", owner: "${owner}") {
           defaultBranchRef {
-            name
+            defaultBranch: name
           }
           refs(first: 100, refPrefix: "refs/heads/") {
             nodes {
@@ -38,12 +38,10 @@ module.exports = async ({ owner = github.owner, repository }) => {
 
   const {
     repository: {
-      defaultBranchRef: {
-        name
-      },
+      defaultBranchRef: { defaultBranch },
       refs: { nodes },
     },
   } = response.data.data;
 
-  return { nodes, defaultBranch: name };
+  return { nodes, defaultBranch };
 };

--- a/src/github/fetchBranches.js
+++ b/src/github/fetchBranches.js
@@ -5,6 +5,9 @@ module.exports = async ({ owner = github.owner, repository }) => {
   const url = `${github.endpoint}/graphql`;
   const query = `{
         repository(name: "${repository}", owner: "${owner}") {
+          defaultBranchRef {
+            name
+          }
           refs(first: 100, refPrefix: "refs/heads/") {
             nodes {
               name
@@ -35,9 +38,12 @@ module.exports = async ({ owner = github.owner, repository }) => {
 
   const {
     repository: {
+      defaultBranchRef: {
+        name
+      },
       refs: { nodes },
     },
   } = response.data.data;
 
-  return nodes;
+  return { nodes, defaultBranchName: name };
 };

--- a/src/github/fetchBranches.test.js
+++ b/src/github/fetchBranches.test.js
@@ -11,6 +11,9 @@ test('fetchBranches() calls Github API', async () => {
     data: {
       data: {
         repository: {
+          defaultBranchRef: {
+            name: 'master',
+          },
           refs: {
             nodes: [],
           },

--- a/src/github/filterStaleBranches.js
+++ b/src/github/filterStaleBranches.js
@@ -1,6 +1,5 @@
 const { github } = require('../config');
 
-// filters stale, default and excluded branches
 module.exports = ({ nodes, defaultBranch = null, excludedBranches = github.exclude }) => {
   const past = new Date();
   past.setMonth(past.getMonth() - 3);

--- a/src/github/filterStaleBranches.js
+++ b/src/github/filterStaleBranches.js
@@ -1,13 +1,13 @@
 const { github } = require('../config');
 
 // filters stale, default and excluded branches
-module.exports = ({ nodes, defaultBranchName = null, excludedBranches = github.exclude }) => {
+module.exports = ({ nodes, defaultBranch = null, excludedBranches = github.exclude }) => {
   const past = new Date();
   past.setMonth(past.getMonth() - 3);
 
   const staleBranches = nodes
     .filter(({ target: { committedDate } }) => Date.parse(committedDate) < past)
-    .filter(({ name }) => ![...excludedBranches, defaultBranchName].filter(Boolean).includes(name));
+    .filter(({ name }) => ![...excludedBranches, defaultBranch].filter(Boolean).includes(name));
 
   staleBranches.sort((a, b) => a.target.committedDate.localeCompare(b.target.committedDate));
 

--- a/src/github/filterStaleBranches.js
+++ b/src/github/filterStaleBranches.js
@@ -1,12 +1,13 @@
 const { github } = require('../config');
 
-module.exports = ({ nodes, excludedBranches = github.exclude }) => {
+// filters stale, default and excluded branches
+module.exports = ({ nodes, defaultBranchName = null, excludedBranches = github.exclude }) => {
   const past = new Date();
   past.setMonth(past.getMonth() - 3);
 
   const staleBranches = nodes
     .filter(({ target: { committedDate } }) => Date.parse(committedDate) < past)
-    .filter(({ name }) => !excludedBranches.includes(name));
+    .filter(({ name }) => ![...excludedBranches, defaultBranchName].filter(Boolean).includes(name));
 
   staleBranches.sort((a, b) => a.target.committedDate.localeCompare(b.target.committedDate));
 

--- a/src/github/filterStaleBranches.test.js
+++ b/src/github/filterStaleBranches.test.js
@@ -26,13 +26,13 @@ describe('filterStaleBranches()', () => {
     });
 
     it('default branch', async () => {
-      const defaultBranchName = 'master';
+      const defaultBranch = 'master';
       // when
-      const branches = filterStaleBranches({ nodes, defaultBranchName });
+      const branches = filterStaleBranches({ nodes, defaultBranch });
 
       // then
       expect(branches.map(({ name }) => name)).toEqual(
-        expect.not.arrayContaining([defaultBranchName])
+        expect.not.arrayContaining([defaultBranch])
       );
     });
 

--- a/src/github/findStaleBranches.js
+++ b/src/github/findStaleBranches.js
@@ -2,6 +2,6 @@ const fetchBranches = require('./fetchBranches');
 const filterStaleBranches = require('./filterStaleBranches');
 
 module.exports = async ({ owner, repository }) => {
-  const nodes = await fetchBranches({ owner, repository });
-  return filterStaleBranches({ nodes });
+  const { nodes, defaultBranchName } = await fetchBranches({ owner, repository });
+  return filterStaleBranches({ nodes, defaultBranchName });
 };

--- a/src/github/findStaleBranches.js
+++ b/src/github/findStaleBranches.js
@@ -2,6 +2,6 @@ const fetchBranches = require('./fetchBranches');
 const filterStaleBranches = require('./filterStaleBranches');
 
 module.exports = async ({ owner, repository }) => {
-  const { nodes, defaultBranchName } = await fetchBranches({ owner, repository });
-  return filterStaleBranches({ nodes, defaultBranchName });
+  const { nodes, defaultBranch } = await fetchBranches({ owner, repository });
+  return filterStaleBranches({ nodes, defaultBranch });
 };

--- a/src/github/findStaleBranches.test.js
+++ b/src/github/findStaleBranches.test.js
@@ -9,6 +9,12 @@ jest.mock('./filterStaleBranches');
 describe('findStaleBranches()', () => {
   const owner = 'TestOwner';
   const repository = 'test-repository';
+  const nodes = [];
+  const defaultBranchName = 'master';
+
+  beforeEach(() => {
+    fetchBranches.mockResolvedValue({ nodes, defaultBranchName });
+  });
 
   afterEach(() => {
     fetchBranches.mockClear();
@@ -22,12 +28,9 @@ describe('findStaleBranches()', () => {
   });
 
   it('calls filterStaleBranches', async () => {
-    const nodes = [];
-    fetchBranches.mockResolvedValue(nodes);
-
     await findStaleBranches({ owner, repository });
 
     expect(filterStaleBranches).toBeCalledTimes(1);
-    expect(filterStaleBranches).toBeCalledWith({ nodes });
+    expect(filterStaleBranches).toBeCalledWith({ nodes, defaultBranchName });
   });
 });

--- a/src/github/findStaleBranches.test.js
+++ b/src/github/findStaleBranches.test.js
@@ -10,10 +10,10 @@ describe('findStaleBranches()', () => {
   const owner = 'TestOwner';
   const repository = 'test-repository';
   const nodes = [];
-  const defaultBranchName = 'master';
+  const defaultBranch = 'master';
 
   beforeEach(() => {
-    fetchBranches.mockResolvedValue({ nodes, defaultBranchName });
+    fetchBranches.mockResolvedValue({ nodes, defaultBranch });
   });
 
   afterEach(() => {
@@ -31,6 +31,6 @@ describe('findStaleBranches()', () => {
     await findStaleBranches({ owner, repository });
 
     expect(filterStaleBranches).toBeCalledTimes(1);
-    expect(filterStaleBranches).toBeCalledWith({ nodes, defaultBranchName });
+    expect(filterStaleBranches).toBeCalledWith({ nodes, defaultBranch });
   });
 });


### PR DESCRIPTION
Closes #4 

https://github.com/prodigyeducation/branch-cleaner/pull/12 added excluding certain branches set in the config. This PR excludes the default branch, as the default branch `master` should never be deleted.

Note that I have no idea how to run this to test :P (@DaleSeo show me the way!) I'm relying on the jest tests.