### PR TITLE
Add documentation on usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,9 @@ curl "http://localhost:9000/remind?owner=<owner>&repository=<repository>&channel
 curl -X POST "http://localhost:9000/slack" -d "<slack request payload>"
 ```
 
-## Configurations
+## How to use?
 
-Use environment variables or create `.env` file to define the following config items.
-
--   GITHUB_TOKEN
--   SLACK_TOKEN
--   SLACK_SIGNING_SECRET
+Please see [the documentation on usage](./docs/USAGE.md).
 
 ## Commands
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,7 +5,7 @@
 Branch Cleaner performs operations against [Github API](https://developer.github.com/v4) and [Slack API](https://api.slack.com) on behalf of your team.
 Therefore, there is some preliminary work to be done on both platforms.
 
-### Github 
+### Github
 
 An access token should be created with proper permissions so that Branch Cleaner can fetch all branches and delete certain branches on request.
 This newly created token should be set for the `GITHUB_TOKEN` environment variable of Branch Cleaner.
@@ -16,38 +16,36 @@ For more information on how to create access tokens on Github, please refer to [
 
 1. Add and install an app to your workspace
 
-    An app should be added and installed to your workspace at [the Your Apps page](https://api.slack.com/apps) on Slack API.
+   An app should be added and installed to your workspace at [the Your Apps page](https://api.slack.com/apps) on Slack API.
 
 2. Generate OAuth token
 
-    Once the app is installed, an OAuth token will be automatically generated and it will be used to authenticate the app.
-    This OAuth token should be set for the `SLACK_TOKEN` environment variable of Branch Cleaner.
+   Once the app is installed, an OAuth token will be automatically generated and it will be used to authenticate the app.
+   This OAuth token should be set for the `SLACK_TOKEN` environment variable of Branch Cleaner.
 
-    For more information on how to use OAuth 2.0 on Slack, please refer to [the official documentation](https://api.slack.com/docs/oauth).
+   For more information on how to use OAuth 2.0 on Slack, please refer to [the official documentation](https://api.slack.com/docs/oauth).
 
 3. Generate Signing Secret
 
-    Once the app is added, a signing secret will be automatically generated and it will be use to verify requests from Slack.
-    This signing secret should be set for the `SLACK_SIGNING_SECRET` environment variable of Branch Cleaner.
+   Once the app is added, a signing secret will be automatically generated and it will be use to verify requests from Slack.
+   This signing secret should be set for the `SLACK_SIGNING_SECRET` environment variable of Branch Cleaner.
 
-    For more information on how to verify requests from SLack, please refer to [the official documentation](https://api.slack.com/docs/verifying-requests-from-slack).
-
+   For more information on how to verify requests from Slack, please refer to [the official documentation](https://api.slack.com/docs/verifying-requests-from-slack).
 
 ## Configuration
 
 As described in the table below, there are some environment variables to be set for Branch Cleaner to function properly.
 You can also create a `.env` file on the project root and define config items instead.
 
-Environment Variable|Description|Default value|Required
--|-|-|-
-GITHUB_ENDPOINT|Github API Endpoint (v4)|https://api.github.com|No
-GITHUB_TOKEN|Github Access Token|-|Yes
-GITHUB_OWNER|Github Owner Name|-|No
-GITHUB_EXCLUDE|Branch names to exclude|-|No
-SLACK_ENDPOINT|Slack API Endpoint|https://slack.com/api|No
-SLACK_TOKEN|Slack OAuth Token|-|Yes
-SLACK_SIGNING_SECRET|Slack Signing Token|-|Yes
-
+| Environment Variable | Description                                                                            | Default value          | Required |
+| -------------------- | -------------------------------------------------------------------------------------- | ---------------------- | -------- |
+| GITHUB_ENDPOINT      | Github API Endpoint (v4)                                                               | https://api.github.com | No       |
+| GITHUB_TOKEN         | Github Access Token. Used to authorize Branch Cleaner to access the Github repository. | -                      | Yes      |
+| GITHUB_OWNER         | Github Owner Name. If specified, don't need to pass an owner name as a URI parameter.  | -                      | No       |
+| GITHUB_EXCLUDE       | Branch names to exclude. Specified branch names are not considered stale.              | -                      | No       |
+| SLACK_ENDPOINT       | Slack API Endpoint                                                                     | https://slack.com/api  | No       |
+| SLACK_TOKEN          | Slack OAuth Token. Used to authorize Branch Cleaner to post Slack messages.            | -                      | Yes      |
+| SLACK_SIGNING_SECRET | Slack Signing Token. Used to verify requests to Branch Cleaner are coming from Slack.  | -                      | Yes      |
 
 ## Deployment
 
@@ -59,7 +57,7 @@ Branch Cleaner is shipped with lambda functions. So, it can be hosted on Netlify
 
 For more information on Netlify Functions, please refer to the [official documentation](https://www.netlify.com/products/functions/)
 
-## Stand-alone Server
+### Stand-alone Server
 
 You can keep Branch Cleaner running as a stand-alone server on any machine using the following command.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,68 @@
+# How to use Branch Cleaner
+
+## Setup
+
+Branch Cleaner performs operations against [Github API](https://developer.github.com/v4) and [Slack API](https://api.slack.com) on behalf of your team.
+Therefore, there is some preliminary work to be done on both platforms.
+
+### Github 
+
+An access token should be created with proper permissions so that Branch Cleaner can fetch all branches and delete certain branches on request.
+This newly created token should be set for the `GITHUB_TOKEN` environment variable of Branch Cleaner.
+
+For more information on how to create access tokens on Github, please refer to [the official documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
+
+### Slack
+
+1. Add and install an app to your workspace
+
+    An app should be added and installed to your workspace at [the Your Apps page](https://api.slack.com/apps) on Slack API.
+
+2. Generate OAuth token
+
+    Once the app is installed, an OAuth token will be automatically generated and it will be used to authenticate the app.
+    This OAuth token should be set for the `SLACK_TOKEN` environment variable of Branch Cleaner.
+
+    For more information on how to use OAuth 2.0 on Slack, please refer to [the official documentation](https://api.slack.com/docs/oauth).
+
+3. Generate Signing Secret
+
+    Once the app is added, a signing secret will be automatically generated and it will be use to verify requests from Slack.
+    This signing secret should be set for the `SLACK_SIGNING_SECRET` environment variable of Branch Cleaner.
+
+    For more information on how to verify requests from SLack, please refer to [the official documentation](https://api.slack.com/docs/verifying-requests-from-slack).
+
+
+## Configuration
+
+As described in the table below, there are some environment variables to be set for Branch Cleaner to function properly.
+You can also create a `.env` file on the project root and define config items instead.
+
+Environment Variable|Description|Default value|Required
+-|-|-|-
+GITHUB_ENDPOINT|Github API Endpoint (v4)|https://api.github.com|No
+GITHUB_TOKEN|Github Access Token|-|Yes
+GITHUB_OWNER|Github Owner Name|-|No
+GITHUB_EXCLUDE|Branch names to exclude|-|No
+SLACK_ENDPOINT|Slack API Endpoint|https://slack.com/api|No
+SLACK_TOKEN|Slack OAuth Token|-|Yes
+SLACK_SIGNING_SECRET|Slack Signing Token|-|Yes
+
+
+## Deployment
+
+Though it is recommended to host Branch Cleaner on Netlify, it can be also deployed as a stand-alone server to any environment.
+
+### Netlify
+
+Branch Cleaner is shipped with lambda functions. So, it can be hosted on Netlify just like other static websites without any other backends.
+
+For more information on Netlify Functions, please refer to the [official documentation](https://www.netlify.com/products/functions/)
+
+## Stand-alone Server
+
+You can keep Branch Cleaner running as a stand-alone server on any machine using the following command.
+
+```
+$ npm start
+```


### PR DESCRIPTION
There was feedback that `README.md` page may not have all the information a person wanting to run Branch Cleaner for themselves would want. To address this feedback, I put clearer set-up instructions leaving the `README.md` page as a high-level intro.

As a side note, I think there is too much work to be done on Slack. This is mainly because Branch Cleaner hasn't been published to Slack App Directory yet. If it was there, people could just install the app without having to create their own. Just created issue #31 so anyone who has done this before can help.