### PR TITLE
Automate linting & testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on: [push]
+
+jobs:
+  lint:
+    name: Lint (ESLint)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: npm install and lint
+      run: |
+        npm ci
+        npm run lint
+  test:
+    name: Test (Jest)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node-version: [8.x, 10.x, 12.x]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install and test
+      run: |
+        npm ci
+        npm test
+        


### PR DESCRIPTION
Resolves  #18.

This PR automates linting and testing on the project using Github Actions. We've come across unlinted or untested code pushed to the repository several times before because we've only relied on contributors running the linter before pushing their code. This issue can be easily solved by having a simple workflow run by Github on every push. I was totally inspired by the other open-sourced project, [python-graphql-client](https://github.com/prodigyeducation/python-graphql-client) that already started using Github Actions to solve similar problems.